### PR TITLE
Revert "remove slow NodeList-static-length-getter-tampered tests"

### DIFF
--- a/dom/nodes/NodeList-static-length-getter-tampered-1.html
+++ b/dom/nodes/NodeList-static-length-getter-tampered-1.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<meta charset="utf-8">
+<meta name=timeout content=long>
+<title>NodeList (static collection) "length" getter tampered</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<body>
+
+<script src="support/NodeList-static-length-tampered.js"></script>
+<script>
+test(() => {
+    const nodeList = makeStaticNodeList(100);
+
+    for (var i = 0; i < 50; i++) {
+        if (i === 25)
+            Object.defineProperty(nodeList, "length", { get() { return 10; } });
+
+        assert_equals(indexOfNodeList(nodeList), i >= 25 ? -1 : 50);
+    }
+});
+</script>

--- a/dom/nodes/NodeList-static-length-getter-tampered-2.html
+++ b/dom/nodes/NodeList-static-length-getter-tampered-2.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<meta charset="utf-8">
+<meta name=timeout content=long>
+<title>NodeList (static collection) "length" getter tampered</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<body>
+
+<script src="support/NodeList-static-length-tampered.js"></script>
+<script>
+test(() => {
+    const nodeList = makeStaticNodeList(100);
+
+    for (var i = 0; i < 50; i++) {
+        if (i === 25)
+            Object.setPrototypeOf(nodeList, { get length() { return 10; } });
+
+        assert_equals(indexOfNodeList(nodeList), i >= 25 ? -1 : 50);
+    }
+});
+</script>

--- a/dom/nodes/NodeList-static-length-getter-tampered-3.html
+++ b/dom/nodes/NodeList-static-length-getter-tampered-3.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<meta charset="utf-8">
+<meta name=timeout content=long>
+<title>NodeList (static collection) "length" getter tampered</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<body>
+
+<script src="support/NodeList-static-length-tampered.js"></script>
+<script>
+test(() => {
+    const nodeList = makeStaticNodeList(100);
+
+    for (var i = 0; i < 50; i++) {
+        if (i === 25)
+            Object.defineProperty(NodeList.prototype, "length", { get() { return 10; } });
+
+        assert_equals(indexOfNodeList(nodeList), i >= 25 ? -1 : 50);
+    }
+});
+</script>

--- a/dom/nodes/NodeList-static-length-getter-tampered-indexOf-1.html
+++ b/dom/nodes/NodeList-static-length-getter-tampered-indexOf-1.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<meta charset="utf-8">
+<meta name=timeout content=long>
+<title>NodeList (static collection) "length" getter tampered (Array.prototype.indexOf)</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<body>
+
+<script src="support/NodeList-static-length-tampered.js"></script>
+<script>
+test(() => {
+    const nodeList = makeStaticNodeList(100);
+
+    for (var i = 0; i < 50; i++) {
+        if (i === 25)
+            Object.defineProperty(nodeList, "length", { get() { return 10; } });
+
+        assert_equals(arrayIndexOfNodeList(nodeList), i >= 25 ? -1 : 50);
+    }
+});
+</script>

--- a/dom/nodes/NodeList-static-length-getter-tampered-indexOf-2.html
+++ b/dom/nodes/NodeList-static-length-getter-tampered-indexOf-2.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<meta charset="utf-8">
+<meta name=timeout content=long>
+<title>NodeList (static collection) "length" getter tampered (Array.prototype.indexOf)</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<body>
+
+<script src="support/NodeList-static-length-tampered.js"></script>
+<script>
+test(() => {
+    const nodeList = makeStaticNodeList(100);
+
+    for (var i = 0; i < 50; i++) {
+        if (i === 25)
+            Object.setPrototypeOf(nodeList, { get length() { return 10; } });
+
+        assert_equals(arrayIndexOfNodeList(nodeList), i >= 25 ? -1 : 50);
+    }
+});
+</script>

--- a/dom/nodes/NodeList-static-length-getter-tampered-indexOf-3.html
+++ b/dom/nodes/NodeList-static-length-getter-tampered-indexOf-3.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<meta charset="utf-8">
+<meta name=timeout content=long>
+<title>NodeList (static collection) "length" getter tampered (Array.prototype.indexOf)</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<body>
+
+<script src="support/NodeList-static-length-tampered.js"></script>
+<script>
+test(() => {
+    const nodeList = makeStaticNodeList(100);
+
+    for (var i = 0; i < 50; i++) {
+        if (i === 25)
+            Object.defineProperty(NodeList.prototype, "length", { get() { return 10; } });
+
+        assert_equals(arrayIndexOfNodeList(nodeList), i >= 25 ? -1 : 50);
+    }
+});
+</script>


### PR DESCRIPTION
This reverts commit 89549fce0b0074228a61cb58ee9679c6e1c587cd.

relates to https://github.com/lightpanda-io/browser/issues/349