### PR TITLE
add WebDriver.getNamedCookie to get access to http-only cookies

### DIFF
--- a/resources/testdriver-vendor.js
+++ b/resources/testdriver-vendor.js
@@ -13,6 +13,18 @@ window.test_driver_internal.get_computed_label = function(element) {
 	return Promise.resolve(window.webdriver.getComputedLabel(element));
 };
 
+window.test_driver_internal.get_named_cookie = function(name, context) {
+	const cookie = window.webdriver.getNamedCookie(name);
+	if (!cookie) {
+		return Promise.resolve(null);
+	}
+	// A session cookie has no expiry; WebDriver omits the field entirely.
+	if (cookie.expiry == null) {
+		delete cookie.expiry;
+	}
+	return Promise.resolve(cookie);
+};
+
 window.test_driver_internal.action_sequence = function(actions, context) {
 	return window.webdriver.actionSequence(actions);
 };


### PR DESCRIPTION
Needed by https://github.com/lightpanda-io/browser/pull/2995